### PR TITLE
Upgraded tartiflette pinning

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     packages=find_packages(exclude=["tests*"]),
     include_package_data=True,
     zip_safe=False,
-    install_requires=["starlette>=0.12,<0.13", "tartiflette>=0.12,<0.13"],
+    install_requires=["starlette>=0.12,<0.13", "tartiflette>=0.12,<1.1"],
     extras_require={
         "dev": [
             "uvicorn>=0.7, <0.9",


### PR DESCRIPTION
Upgraded `tartiflette` pinning from `<0.13` to `<1.1`

Fixes #49 