### PR TITLE
add python 3.8 in travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ dist: xenial
 python:
   - "3.6"
   - "3.7"
+  - "3.8-dev"
 
 before_install:
   - sudo apt-get install cmake flex bison


### PR DESCRIPTION
Adds python 3.8 in build matrix inside travis CI file. Fixes #54 

Test run: https://github.com/saadismail/tartiflette-starlette/runs/246106960