### PR TITLE
Add py.typed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 *.pyc
-venv/
+venv*/
 bin/
 build/
 develop-eggs/

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,6 @@
 # Things to include in the built package (besides the packages defined in setup.py)
 include README.md
+include CHANGELOG.md
 include LICENSE
 include tartiflette_starlette/graphiql.html
+include tartiflette_starlette/py.typed

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
     long_description_content_type="text/markdown",
     url="https://github.com/tartiflette/tartiflette-starlette",
     packages=get_packages("tartiflette_starlette"),
+    package_data={"tartiflette_starlette": ["py.typed"]},
     include_package_data=True,
     zip_safe=False,
     install_requires=["starlette>=0.12,<0.13", "tartiflette>=0.12,<0.13"],


### PR DESCRIPTION
Fixes #59 

Tested by running:


```bash
. venv/bin/activate
pip install wheel
python setup.py dist bdist_wheel
tar -tzf dist/tartiflette-starlette-0.5.1.tar.gz | grep py.typed  # Shows py.typed
deactivate
python -m venv venv-test
. venv-test/bin/activate
pip install dist/tartiflette-starlette-0.5.1.tar.gz
find venv-test -name "py.typed"  # Shows py.typed
```