### PR TITLE
Upgrade Python 3.8-dev to 3.8 in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ branches:
 python:
   - 3.6
   - 3.7
-  - 3.8-dev
+  - 3.8
 
 jobs:
   include:

--- a/setup.py
+++ b/setup.py
@@ -51,5 +51,6 @@ setup(
         "Programming Language :: Python :: 3 :: Only",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
     ],
 )


### PR DESCRIPTION
Python 3.8 was released on October 14th and is now available on Travis CI.